### PR TITLE
Fixes dyn executable by requiring awful

### DIFF
--- a/bin/dyn
+++ b/bin/dyn
@@ -1,4 +1,7 @@
 #!/usr/bin/ruby
 #-*- mode: ruby; -*-
+
+require 'awful'
 require 'awful/dynamodb'
+
 Awful::DynamoDB.start(ARGV)


### PR DESCRIPTION
This fixes the error I've been seeing since reinstalling awful.

```
$ dyn scan my-table
/Users/Buccolo/.gem/ruby/2.1.7/gems/awful-0.0.86/lib/awful/dynamodb_streams.rb:8:in `<module:Awful>': uninitialized constant Awful::Cli (NameError)
        from /Users/Buccolo/.gem/ruby/2.1.7/gems/awful-0.0.86/lib/awful/dynamodb_streams.rb:1:in `<top (required)>'
        from /opt/rubies/2.1.7/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
        from /opt/rubies/2.1.7/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
        from /Users/Buccolo/.gem/ruby/2.1.7/gems/awful-0.0.86/lib/awful/dynamodb.rb:1:in `<top (required)>'
        from /opt/rubies/2.1.7/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
        from /opt/rubies/2.1.7/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
        from /Users/Buccolo/.gem/ruby/2.1.7/gems/awful-0.0.86/bin/dyn:3:in `<top (required)>'
        from /Users/Buccolo/.gem/ruby/2.1.7/bin/dyn:23:in `load'
        from /Users/Buccolo/.gem/ruby/2.1.7/bin/dyn:23:in `<main>'
```

The other executables are fine :+1: 

Culprit: https://github.com/rlister/awful/commit/0d13d6abff553d2cc7b7096b582af22a27151fd4
