### PR TITLE
Remove output buffer from dynamodb copy

### DIFF
--- a/awful.gemspec
+++ b/awful.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency('aws-sdk', '>= 2.2.20')
+  spec.add_dependency('aws-sdk', '>= 2.4.3')
   spec.add_dependency('thor')
   spec.add_dependency('dotenv')
 end


### PR DESCRIPTION
`puts` flushes the output `print` does not. For the use case in this method (progress bar) is better to just to remove the buffer entirely from `STDOUT`
